### PR TITLE
Phase 3.0 prep: three-way scheduler comparison benchmark (loop-safe)

### DIFF
--- a/BACKLOG_PARKING_LOT.md
+++ b/BACKLOG_PARKING_LOT.md
@@ -85,3 +85,42 @@
   **Phase 3 GATED idle-CPU gate** (`≈0` per `dae34f6d`), which will inherit this harness — so it
   should be decided before that gate is wired. Phase 3 is GATED, so this does not block the loop.
 - **Date parked:** 2026-06-17
+
+### 🔴 GATES PHASE 3 G8 — Pin / pre-warm .NET ThreadPool + re-run at a real BDN job before the Phase 3 acceptance benchmark
+- **Source:** RALPH run phase3-prep, after-action adversarial review (postmortem), triage #5 (§B/§F)
+  — see `.ralph/runs/phase3-prep/postmortem.md` (PARK-B)
+- **Issue:** The P3.0.1 landscape rig (memorizer `1eeb3867`) is labelled PRELIMINARY and is honest
+  about two methodology limits, but those limits make its headline numbers **unsafe to feed the gated
+  Phase 3 G8 acceptance decision** as-is:
+  - **Unconstrained TP at `WorkerCount=2`:** the `0.62` "Helios faster at 2w" ratio compares a 2-worker
+    Helios against an **unconstrained ~8-worker, cold-ramping .NET ThreadPool** (the .NET TP can't be
+    held to 2 threads without a global `SetMaxThreads`). Apples-to-oranges — must NOT be quoted as a
+    parity finding.
+  - **High error bars at ShortRun:** Error ≈ Mean for the .NET TP rows (e.g. Error 9.0ms on a 10.0ms
+    Mean), so the `1.05` / `0.62` ratios are statistically soft.
+- **Decision needed:** Before the **Phase 3 G8** parity/convergence gate consumes any of these numbers,
+  re-run the comparison with (a) a pinned / pre-warmed .NET ThreadPool (e.g. `SetMinThreads`/`SetMaxThreads`
+  + warm-up invocations so the TP isn't cold-ramping) so the WorkerCount config is a fair like-for-like
+  comparison, and (b) a **real BDN job** (not ShortRun) so the error bars tighten per discipline `dae34f6d`.
+  This is **NOT a NOW fix** — Phase 3 is `[GATED]` and human-gated, so the loop never reaches G8; but this
+  is the item that unblocks an honest G8 acceptance decision and should be done as part of standing up that
+  gate. **Prominence: this is the highest-priority park item — it gates the Phase 3 G8 acceptance benchmark.**
+- **Date parked:** 2026-06-17
+
+### iter-log has no `## Commits` section listing its hex hash (ralph-loop template gap)
+- **Source:** RALPH run phase3-prep, after-action — flagged by **both** review stages (diagnostics
+  finding G3/SP-2 + adversarial triage #4) — see `.ralph/runs/phase3-prep/postmortem.md` (PARK-A)
+- **Issue:** `iter-01.md` has no `## Commits` section listing its actual commit hash (`bb63a41`), which
+  violates the review skill's must-check (line 472: every iter log must list its hex commit hash). Because
+  the log relied on git correlation instead, the STAGE 1 `gather-context` step had to perform an
+  orphaned-commit hunt to map commits ↔ logs — and it surfaced the orphaned run-start commit `71a4122`
+  (the plan-seeding commit recorded in `run.md` as the start commit but covered by no iteration log). This
+  is a **2+-occurrence pattern**: both reviewers independently landed on the missing-commit-record gap in a
+  single run.
+- **Decision needed:** Process call (skill edit needs maintainer sign-off). The postmortem drafts a concrete
+  fix: add a `## Commits` section **gate** to the `ralph-loop.md` iteration template (every `iter-NN.md` must
+  list each commit's hex hash + one-line description) plus a `## Pre-run prep commits:` rule in `run.md` for
+  any commit made before `iter-01`, and a Step-13 loop-advance gate that refuses to advance until the
+  just-finished iter-log has a non-empty, git-resolvable `## Commits` section. All additive; needs sign-off
+  before the skill files are edited.
+- **Date parked:** 2026-06-17

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,24 +1,21 @@
 <Project>
-
   <!--
     Central Package Management. All PackageReference versions live here;
     .csproj files reference packages by name only.
     https://learn.microsoft.com/nuget/consume-packages/central-package-management
   -->
-
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Test stack: xUnit + VSTest adapter + coverlet. -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <!-- Perf harness: BenchmarkDotNet (migrated from NBench in Phase 2). -->
+    <!-- Perf harness: BenchmarkDotNet + Pipelines.Sockets.Unofficial (benchmarks-only comparison target). -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.16" />
   </ItemGroup>
-
 </Project>

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -275,10 +275,11 @@ Establishes the comparison rig and targets the gated Phase 3 core will be judged
 **Source:** Phase 3 prep + StackExchange.Redis #3060 (memorizer `eb4916e3` §4): we must "beat the lock-y 7-year-old `DedicatedThreadPoolPipeScheduler` on 2 cores."
 **Scope guardrail (READ):** Benchmark only the **three schedulers that already exist today** — the current `Helios.Concurrency.DedicatedThreadPool` (`QueueUserWorkItem`), `System.Threading.ThreadPool` (`UnsafeQueueUserWorkItem`), and `Pipelines.Sockets.Unofficial.DedicatedThreadPoolPipeScheduler` (`Schedule`). **Do NOT design, stub, or implement the new lock-free pool — that is Phase 3, `[GATED]`.** This task only stands up the measurement rig + records where the *current* landscape sits.
 **Done when:**
-- [ ] Add a BenchmarkDotNet benchmark to the existing `*.Benchmarks` project comparing the three schedulers on a small-work-item throughput workload, at the default thread count **and** a constrained (e.g. 2-thread) config. Add `Pipelines.Sockets.Unofficial` as a **benchmarks-only** PackageReference (CPM) — NOT a dependency of the shipped library.
-- [ ] `[MemoryDiagnoser]`; smoke-runs under `build.ps1 Benchmark -Smoke` (CI `--job dry`) and runs fully on the dev box.
-- [ ] Record the preliminary comparison numbers to memorizer (new record, linked to the spec) — clearly labelled preliminary per the baseline discipline in `TOOLING.md`; note this is the "landscape the rewritten pool must beat."
+- [x] Add a BenchmarkDotNet benchmark to the existing `*.Benchmarks` project comparing the three schedulers on a small-work-item throughput workload, at the default thread count **and** a constrained (e.g. 2-thread) config. Add `Pipelines.Sockets.Unofficial` as a **benchmarks-only** PackageReference (CPM) — NOT a dependency of the shipped library.
+- [x] `[MemoryDiagnoser]`; smoke-runs under `build.ps1 Benchmark -Smoke` (CI `--job dry`) and runs fully on the dev box.
+- [x] Record the preliminary comparison numbers to memorizer (new record, linked to the spec) — clearly labelled preliminary per the baseline discipline in `TOOLING.md`; note this is the "landscape the rewritten pool must beat."
 **Verification:** L1 (perf: build + BDN runs; raw output read directly; recorded to memorizer).
+**✅ Resolved 2026-06-17 (phase3-prep iter-01):** `SchedulerComparisonBenchmarks.cs` added; `Pipelines.Sockets.Unofficial` v2.2.16 added as benchmarks-only CPM dep; `Program.cs` migrated to `BenchmarkSwitcher` for correct multi-class filtering. ShortRun (3 iter, 3 warmup): Helios 10.5ms ≈ parity with .NET TP (10.0ms, ratio 1.05) at 8w; Helios 7.0ms vs .NET TP 11.4ms (ratio 0.62) at 2w; PipeScheduler 3× slower than .NET TP in both configs with 47K–66K Monitor contentions per run vs 0 for Helios. Landscape recorded to memorizer `1eeb3867-a9af-4d45-b93b-c4a593fcec95` (BASELINE-FOR spec `2c734cfb`).
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -281,6 +281,28 @@ Establishes the comparison rig and targets the gated Phase 3 core will be judged
 **Verification:** L1 (perf: build + BDN runs; raw output read directly; recorded to memorizer).
 **✅ Resolved 2026-06-17 (phase3-prep iter-01):** `SchedulerComparisonBenchmarks.cs` added; `Pipelines.Sockets.Unofficial` v2.2.16 added as benchmarks-only CPM dep; `Program.cs` migrated to `BenchmarkSwitcher` for correct multi-class filtering. ShortRun (3 iter, 3 warmup): Helios 10.5ms ≈ parity with .NET TP (10.0ms, ratio 1.05) at 8w; Helios 7.0ms vs .NET TP 11.4ms (ratio 0.62) at 2w; PipeScheduler 3× slower than .NET TP in both configs with 47K–66K Monitor contentions per run vs 0 for Helios. Landscape recorded to memorizer `1eeb3867-a9af-4d45-b93b-c4a593fcec95` (BASELINE-FOR spec `2c734cfb`).
 
+### Cleanup (phase3-prep after-action — non-blocking, fold into next benchmark/record touch)
+
+*Source: phase3-prep after-action postmortem (`.ralph/runs/phase3-prep/postmortem.md`). No NOW
+fix-it was required (overall verdict PARTIAL, driven by process/auditability gaps, not code defects).*
+
+- [ ] **C6-1** `[LOOP-OK]` Bound the benchmark's `done.Wait()`. The per-invocation drain in
+      `SchedulerComparisonBenchmarks.cs` calls an **unbounded** `done.Wait()`; if a scheduler ever
+      drops a work item the harness hangs forever instead of failing loud in CI. Add a timeout +
+      throw on the next benchmark touch. Perf/test code only — loop-safe. *(postmortem.md)*
+      **Verification:** L1 (perf: build + BDN smoke green).
+- [ ] **C6-2** `[LOOP-OK]` Restore the `Directory.Packages.props` trailing newline. `bb63a41`
+      stripped the final `\n` (and added incidental blank-line churn). Cosmetic hygiene; trivially
+      loop-safe. *(postmortem.md)*
+      **Verification:** L1 (release: build green; no behavior change).
+- [ ] **C6-3** Correct the "100000 contentions" label in memorizer `1eeb3867`. The recorded .NET TP
+      contention figure equals *exactly* WorkItems (100,000) — almost certainly Interlocked/lock-release
+      events mislabeled as `Monitor` contention by the BDN Threading diagnoser. Conclusion unaffected
+      (PipeScheduler is the contention loser; Helios = 0); the label merely misleads. **Not `[LOOP-OK]`**
+      — requires a memorizer write to a record feeding the gated Phase 3 decision; best batched with the
+      PARK-B re-run that rewrites this record. *(postmortem.md)*
+      **Verification:** L1 (perf: corrected record read directly, recorded to memorizer).
+
 ---
 
 ## Phase 3 — Pool core rewrite (IoExecutor spec P1)  ·  MODE=engineering  ·  **NEXT** · `[GATED]`

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -266,6 +266,22 @@ baseline is recorded for the pre-rewrite pool.
 
 ---
 
+## Phase 3.0 — Prep (loop-safe groundwork before the gated core)  ·  MODE=perf  ·  **NOW**
+
+Establishes the comparison rig and targets the gated Phase 3 core will be judged against —
+**without** building any new pool. (Loop-safe: benchmarks only EXISTING types.)
+
+### Task P3.0.1: BenchmarkDotNet comparison harness — current pool vs .NET ThreadPool vs DedicatedThreadPoolPipeScheduler · `[LOOP-OK]`
+**Source:** Phase 3 prep + StackExchange.Redis #3060 (memorizer `eb4916e3` §4): we must "beat the lock-y 7-year-old `DedicatedThreadPoolPipeScheduler` on 2 cores."
+**Scope guardrail (READ):** Benchmark only the **three schedulers that already exist today** — the current `Helios.Concurrency.DedicatedThreadPool` (`QueueUserWorkItem`), `System.Threading.ThreadPool` (`UnsafeQueueUserWorkItem`), and `Pipelines.Sockets.Unofficial.DedicatedThreadPoolPipeScheduler` (`Schedule`). **Do NOT design, stub, or implement the new lock-free pool — that is Phase 3, `[GATED]`.** This task only stands up the measurement rig + records where the *current* landscape sits.
+**Done when:**
+- [ ] Add a BenchmarkDotNet benchmark to the existing `*.Benchmarks` project comparing the three schedulers on a small-work-item throughput workload, at the default thread count **and** a constrained (e.g. 2-thread) config. Add `Pipelines.Sockets.Unofficial` as a **benchmarks-only** PackageReference (CPM) — NOT a dependency of the shipped library.
+- [ ] `[MemoryDiagnoser]`; smoke-runs under `build.ps1 Benchmark -Smoke` (CI `--job dry`) and runs fully on the dev box.
+- [ ] Record the preliminary comparison numbers to memorizer (new record, linked to the spec) — clearly labelled preliminary per the baseline discipline in `TOOLING.md`; note this is the "landscape the rewritten pool must beat."
+**Verification:** L1 (perf: build + BDN runs; raw output read directly; recorded to memorizer).
+
+---
+
 ## Phase 3 — Pool core rewrite (IoExecutor spec P1)  ·  MODE=engineering  ·  **NEXT** · `[GATED]`
 
 Build the reusable core at **fixed** thread count first; prove parity before adapting.

--- a/src/tests/Helios.DedicatedThreadPool.Benchmarks/Helios.DedicatedThreadPool.Benchmarks.csproj
+++ b/src/tests/Helios.DedicatedThreadPool.Benchmarks/Helios.DedicatedThreadPool.Benchmarks.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Pipelines.Sockets.Unofficial" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Helios.DedicatedThreadPool.Benchmarks/Program.cs
+++ b/src/tests/Helios.DedicatedThreadPool.Benchmarks/Program.cs
@@ -1,5 +1,13 @@
-﻿using BenchmarkDotNet.Running;
+﻿using System;
+using System.Linq;
+using BenchmarkDotNet.Running;
 using Helios.Concurrency.Benchmarks;
 
-// Run all methods in ThroughputBenchmarks; forward args so callers can pass e.g. --job dry.
-BenchmarkRunner.Run<ThroughputBenchmarks>(args: args);
+// Discover all benchmark classes in this assembly.
+// Add --filter * by default so unfiltered runs and CI (--job dry) both cover all classes.
+var runArgs = args.Any(a => a.StartsWith("--filter", StringComparison.Ordinal))
+    ? args
+    : [.. args, "--filter", "*"];
+BenchmarkSwitcher
+    .FromAssembly(typeof(ThroughputBenchmarks).Assembly)
+    .Run(runArgs);

--- a/src/tests/Helios.DedicatedThreadPool.Benchmarks/SchedulerComparisonBenchmarks.cs
+++ b/src/tests/Helios.DedicatedThreadPool.Benchmarks/SchedulerComparisonBenchmarks.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using Pipelines.Sockets.Unofficial;
+
+namespace Helios.Concurrency.Benchmarks;
+
+/// <summary>
+/// Three-way throughput comparison: current Helios pool, .NET ThreadPool, and the
+/// lock-based DedicatedThreadPoolPipeScheduler from Pipelines.Sockets.Unofficial.
+/// Run at both default (ProcessorCount) and constrained (2-thread) worker counts to
+/// surface the lock-contention penalty on narrow machines (StackExchange.Redis #3060 scenario).
+/// WorkerCount=0 means Environment.ProcessorCount.
+/// </summary>
+[MemoryDiagnoser]
+public class SchedulerComparisonBenchmarks
+{
+    private const int WorkItems = 100_000;
+
+    // 0 = Environment.ProcessorCount (default), 2 = constrained
+    [Params(0, 2)]
+    public int WorkerCount;
+
+    private DedicatedThreadPool _heliosPool = null!;
+    private DedicatedThreadPoolPipeScheduler _pipeScheduler = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        int count = WorkerCount == 0 ? Environment.ProcessorCount : WorkerCount;
+        _heliosPool = new DedicatedThreadPool(new DedicatedThreadPoolSettings(count));
+        _pipeScheduler = new DedicatedThreadPoolPipeScheduler("bench", workerCount: count);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _heliosPool.Dispose();
+        _pipeScheduler.Dispose();
+    }
+
+    // .NET ThreadPool is not configurable to a fixed worker count without SetMaxThreads,
+    // so it runs at its default thread count in both param configurations.
+    [Benchmark(Baseline = true)]
+    public void DotNetThreadPool()
+    {
+        using var done = new ManualResetEventSlim(false);
+        int remaining = WorkItems;
+        for (int i = 0; i < WorkItems; i++)
+        {
+            ThreadPool.UnsafeQueueUserWorkItem(_ =>
+            {
+                if (Interlocked.Decrement(ref remaining) == 0)
+                    done.Set();
+            }, (object?)null, preferLocal: false);
+        }
+        done.Wait();
+    }
+
+    [Benchmark]
+    public void HeliosPool()
+    {
+        using var done = new ManualResetEventSlim(false);
+        int remaining = WorkItems;
+        for (int i = 0; i < WorkItems; i++)
+        {
+            _heliosPool.QueueUserWorkItem(() =>
+            {
+                if (Interlocked.Decrement(ref remaining) == 0)
+                    done.Set();
+            });
+        }
+        done.Wait();
+    }
+
+    [Benchmark]
+    public void PipeScheduler()
+    {
+        using var done = new ManualResetEventSlim(false);
+        int remaining = WorkItems;
+        for (int i = 0; i < WorkItems; i++)
+        {
+            _pipeScheduler.Schedule(_ =>
+            {
+                if (Interlocked.Decrement(ref remaining) == 0)
+                    done.Set();
+            }, null);
+        }
+        done.Wait();
+    }
+}


### PR DESCRIPTION
Loop-safe groundwork before the `[GATED]` Phase 3 core. Adds a BenchmarkDotNet harness comparing the **three existing schedulers** — current `Helios.DedicatedThreadPool`, `System.Threading.ThreadPool`, and `Pipelines.Sockets.Unofficial.DedicatedThreadPoolPipeScheduler` — to establish the parity landscape and the StackExchange.Redis #3060 "beat the lock-y scheduler on 2 cores" target the rewritten pool will be judged against.

- `Pipelines.Sockets.Unofficial` added as a **benchmarks-only** dependency (not in the shipped library).
- Preliminary comparison recorded to memorizer `1eeb3867` (honestly labelled preliminary; landscape characterisation only).
- **Does not build the new pool** — that's Phase 3, `[GATED]`.

Verdict PARTIAL (process-compliance only: a memorizer-spec citation gap + minor iter-log fields); the harness itself is correct and CI-validated.